### PR TITLE
Wrong lookup value returned in get_display_value

### DIFF
--- a/plugin/item_type_plugin_mho_modal_lov.sql
+++ b/plugin/item_type_plugin_mho_modal_lov.sql
@@ -245,7 +245,7 @@ wwv_flow_api.create_plugin(
 '    , p_min_columns       => 2',
 '    , p_max_columns       => 2',
 '    , p_component_name    => null',
-'    , p_search_type       => apex_plugin_util.c_search_exact_case',
+'    , p_search_type       => apex_plugin_util.c_search_lookup',
 '    , p_search_column_no  => 2',
 '    , p_search_string     => p_return_val',
 '  );',


### PR DESCRIPTION
Function get_display_value is being used to get the corresponding value for a given id, a typical lookup functionality.
 
However function apex_plugin_util.get_data is being called with parameter 'p_search_type => apex_plugin_util.c_search_exact_case', therefor the resulting where clause will look like "where column like p_search_string || '%'". Resulting in an array with a list of possible results.
 
Imagine you are searching for the value corresponding with id 1, but the query executes "where column like '1%'" instead of "where column = 1". It can actually return the value corresponding with id 11 or 123, depending on which the database returns first. When using an order by in your lov query (on a column other than the id-column) it will probably often go wrong.
 
When using  apex_plugin_util.c_search_lookup instead, it will result in where clause 'where column = id' and therefor always return exactly one value corresponding with the the exact id. (the existance of constant c_search_lookup is not documented, but you can find it in the sourcecode specification of package wwv_flow_plugin_util (apex_plugin_util=synonym) )
 
Another solution is using function apex_plugin_util.get_display_data which does exactly the same and always returns one possible answer.